### PR TITLE
Support span tags in rendering description

### DIFF
--- a/lib/contentstack_utils/model/options.rb
+++ b/lib/contentstack_utils/model/options.rb
@@ -105,6 +105,8 @@ module ContentstackUtils
                     renderString = "<code>#{inner_html}</code>"
                 when 'reference'
                     renderString = ""
+                when 'span'
+                    renderString = "<span>#{inner_html}</span>"
                 end
                 renderString
             end

--- a/spec/lib/model/option_spec.rb
+++ b/spec/lib/model/option_spec.rb
@@ -305,5 +305,12 @@ RSpec.describe ContentstackUtils::Model::Options do
             expect(result).to eq ""
         end
 
+        it 'Should return span string for reference node type' do
+            doc = getJson(BlankDocument)
+
+            result = subject.render_node('span', doc, linkText)
+            expect(result).to eq "<span>#{linkText}</span>"
+        end
+
     end
 end


### PR DESCRIPTION
When copy/pasting text into the description field on contentstack. Contentstack will wrap the text in a span tag. This is fine except the open source library doesn't support span tags. As a result, during the write back process the description field is set to an empty string and the entry will fail to import due to validation errors.

This fork of the library will add support for spans. Note I will also open a PR on the open source repo, and reference it in the contenthub rails app as we will need to use this fork until the PR is merged.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204015722962791