### PR TITLE
pin-activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,17 @@ PATH
   remote: .
   specs:
     contentstack_utils (1.1.3)
-      activesupport (>= 3.2)
+      activesupport (~> 5.2)
       nokogiri (~> 1.11)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.3)
+    activesupport (5.2.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     concurrent-ruby (1.2.2)
@@ -26,10 +25,10 @@ GEM
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.8.1)
     minitest (5.18.0)
-    nokogiri (1.13.10)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.10-x64-mingw32)
+    nokogiri (1.14.2-x64-mingw32)
       racc (~> 1.4)
     public_suffix (5.0.1)
     racc (1.6.2)
@@ -54,8 +53,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
     webmock (3.11.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -63,7 +63,6 @@ GEM
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)
-    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby

--- a/contentstack_utils.gemspec
+++ b/contentstack_utils.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^spec/})
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '~> 3.2'
+  s.add_dependency 'activesupport', '~> 5.2'
   s.add_dependency 'nokogiri', '~> 1.11'
 
   s.add_development_dependency 'rake', '~> 13.0.3'


### PR DESCRIPTION
We need to pin active support so bd_content_hub can install the new release of this fork